### PR TITLE
Fix: CardActionArea has no onClick prop like it should.

### DIFF
--- a/packages/rescript-mui-material/src/components/CardActionArea.res
+++ b/packages/rescript-mui-material/src/components/CardActionArea.res
@@ -8,7 +8,7 @@ type classes = {
 }
 
 type props = {
-  ...ButtonBase.publicProps,
+  ...ButtonBase.publicPropsWithOnClick,
   /**
     * Override or extend the styles applied to the component.
     */


### PR DESCRIPTION
 CardActionArea has no onClick prop like it should. I ran into this issue trying to migrate my project to the new mui v5 bindings.