### PR TITLE
Fix Autocomplete's renderOption signature.

### DIFF
--- a/packages/rescript-mui-material/src/components/Autocomplete.res
+++ b/packages/rescript-mui-material/src/components/Autocomplete.res
@@ -519,10 +519,11 @@ type props<'value> = {
     *
     * @param {object} props The props to apply on the li element.
     * @param {T} option The option to render.
-    * @param {object} state The state of the component.
+    * @param {object} state The state of each option.
+    * @param {object} ownerState The state of the Autocomplete component.
     * @returns {ReactNode}
     */
-  renderOption?: ('value, 'value, renderOptionState) => React.element,
+  renderOption?: (JsxDOM.domProps, 'value, renderOptionState, ownerState) => React.element,
   /**
     * Render the selected value.
     *


### PR DESCRIPTION
The first argument is the props passed to the option, there was a missing ownerState.