### PR TITLE
Fix type of anchorEl in Popover, fixes positioning in Popover and Menu

### DIFF
--- a/packages/rescript-mui-material/src/components/Popover.res
+++ b/packages/rescript-mui-material/src/components/Popover.res
@@ -11,7 +11,7 @@ type actions = {updatePosition: unit => unit}
 type anchorEl =
   | @as(null) Null
   | Virtual(Popper.virtualElement)
-  | Element(unit => ReactDOM.domRef)
+  | Element(unit => Js.nullable<Dom.element>)
 
 @unboxed
 type verticalOrigin =


### PR DESCRIPTION
The anchorEl accepts a dom element, not a ref. Since it does not try to resolve the ref, the result is the same as if anchorEl would be missing.

Instead it should accept a nullable dom element.