### PR TITLE
fix: DialogTitle does not extend Typography props

### DIFF
--- a/packages/rescript-mui-material/src/components/DialogTitle.res
+++ b/packages/rescript-mui-material/src/components/DialogTitle.res
@@ -4,7 +4,7 @@ type classes = {
 }
 
 type props = {
-  ...CommonProps.t,
+  ...Typography.publicProps,
   /**
     * The content of the component.
     */


### PR DESCRIPTION
https://v5.mui.com/material-ui/api/dialog-title/#props

resolves #225