### PR TITLE
More CommonProps

### DIFF
--- a/packages/rescript-mui-material/src/components/ButtonBase.res
+++ b/packages/rescript-mui-material/src/components/ButtonBase.res
@@ -125,10 +125,6 @@ type publicProps = {
     */
   rel?: string,
   /**
-    * @default 0
-    */
-  tabIndex?: int,
-  /**
    * The target attribute of the link.
    */
   target?: string,

--- a/packages/rescript-mui-material/src/components/CardHeader.res
+++ b/packages/rescript-mui-material/src/components/CardHeader.res
@@ -14,7 +14,7 @@ type classes = {
 }
 
 type props = {
-  ...CommonProps.t,
+  ...CommonProps.t_NoTitle,
   /**
     * The action to display in the card header.
     */

--- a/packages/rescript-mui-material/src/components/Slider.res
+++ b/packages/rescript-mui-material/src/components/Slider.res
@@ -253,10 +253,6 @@ type sliderProps<'value> = {
     */
   sx?: Sx.props,
   /**
-    * Tab index attribute of the hidden `input` element.
-    */
-  tabIndex?: int,
-  /**
     * The track presentation:
     *
     * - `normal` the track will render a bar representing the slider value.

--- a/packages/rescript-mui-material/src/types/CommonProps.res
+++ b/packages/rescript-mui-material/src/types/CommonProps.res
@@ -134,20 +134,61 @@ type t = {
 
 type clickableProps = {
   ...t,
+  // Focus Events
   onBlur?: ReactEvent.Focus.t => unit,
-  onContextMenu?: ReactEvent.Mouse.t => unit,
-  onDragLeave?: ReactEvent.Mouse.t => unit,
   onFocus?: ReactEvent.Focus.t => unit,
+
+  // Keyboard Events
   onKeyDown?: ReactEvent.Keyboard.t => unit,
   onKeyPress?: ReactEvent.Keyboard.t => unit,
   onKeyUp?: ReactEvent.Keyboard.t => unit,
+
+  // Mouse Events
+  onContextMenu?: ReactEvent.Mouse.t => unit,
+  onDrag?: ReactEvent.Mouse.t => unit,
+  onDragEnd?: ReactEvent.Mouse.t => unit,
+  onDragEnter?: ReactEvent.Mouse.t => unit,
+  onDragExit?: ReactEvent.Mouse.t => unit,
+  onDragLeave?: ReactEvent.Mouse.t => unit,
+  onDragOver?: ReactEvent.Mouse.t => unit,
+  onDragStart?: ReactEvent.Mouse.t => unit,
+  onDrop?: ReactEvent.Mouse.t => unit,
   onMouseDown?: ReactEvent.Mouse.t => unit,
   onMouseEnter?: ReactEvent.Mouse.t => unit,
   onMouseLeave?: ReactEvent.Mouse.t => unit,
   onMouseUp?: ReactEvent.Mouse.t => unit,
+
+  // Touch Events
+  onTouchCancel?: ReactEvent.Touch.t => unit,
+  onTouchCancelCapture?: ReactEvent.Touch.t => unit,
   onTouchEnd?: ReactEvent.Touch.t => unit,
+  onTouchEndCapture?: ReactEvent.Touch.t => unit,
   onTouchMove?: ReactEvent.Touch.t => unit,
+  onTouchMoveCapture?: ReactEvent.Touch.t => unit,
   onTouchStart?: ReactEvent.Touch.t => unit,
+  onTouchStartCapture?: ReactEvent.Touch.t => unit,
+
+  // Pointer Events
+  onGotPointerCapture?: ReactEvent.Pointer.t => unit,
+  onGotPointerCaptureCapture?: ReactEvent.Pointer.t => unit,
+  onLostPointerCapture?: ReactEvent.Pointer.t => unit,
+  onLostPointerCaptureCapture?: ReactEvent.Pointer.t => unit,
+  onPointerCancel?: ReactEvent.Pointer.t => unit,
+  onPointerCancelCapture?: ReactEvent.Pointer.t => unit,
+  onPointerDown?: ReactEvent.Pointer.t => unit,
+  onPointerDownCapture?: ReactEvent.Pointer.t => unit,
+  onPointerEnter?: ReactEvent.Pointer.t => unit,
+  onPointerEnterCapture?: ReactEvent.Pointer.t => unit,
+  onPointerLeave?: ReactEvent.Pointer.t => unit,
+  onPointerLeaveCapture?: ReactEvent.Pointer.t => unit,
+  onPointerMove?: ReactEvent.Pointer.t => unit,
+  onPointerMoveCapture?: ReactEvent.Pointer.t => unit,
+  onPointerOut?: ReactEvent.Pointer.t => unit,
+  onPointerOutCapture?: ReactEvent.Pointer.t => unit,
+  onPointerOver?: ReactEvent.Pointer.t => unit,
+  onPointerOverCapture?: ReactEvent.Pointer.t => unit,
+  onPointerUp?: ReactEvent.Pointer.t => unit,
+  onPointerUpCapture?: ReactEvent.Pointer.t => unit,
 }
 
 type clickablePropsWithOnClick = {

--- a/packages/rescript-mui-material/src/types/CommonProps.res
+++ b/packages/rescript-mui-material/src/types/CommonProps.res
@@ -107,6 +107,10 @@ type t_NoId = {
   style?: ReactDOM.Style.t,
   ref?: ReactDOM.domRef,
   @as("data-testid") dataTestId?: string,
+  /**
+    * @default 0
+    */
+  tabIndex?: int,
 }
 
 type classNameOnly = {className: string}

--- a/packages/rescript-mui-material/src/types/CommonProps.res
+++ b/packages/rescript-mui-material/src/types/CommonProps.res
@@ -121,9 +121,15 @@ type t_NoRef = {
   id?: string,
 }
 
+type t_NoTitle = {
+  ...t_NoId,
+  id?: string,
+}
+
 type t = {
   ...t_NoId,
   id?: string,
+  title?: string,
 }
 
 type clickableProps = {


### PR DESCRIPTION
Moves `tabIndex` to `CommonProps.t_NoId` because it is a global attribute

Add `title` / `t_NoTitle` type to CommonProps, due to the naming conflict in `CardHeader.props`

Adds additional event handlers to `CommonProps.clickableProps`:
  - onDrag
  - onDragEnd
  - onDragEnter
  - onDragExit
  - onDragOver
  - onDragStart
  - onDrop
  - onTouchCancel
  - onTouchCancelCapture
  - onTouchEndCapture
  - onTouchMoveCapture
  - onTouchStartCapture
  - onGotPointerCapture
  - onGotPointerCaptureCapture
  - onLostPointerCapture
  - onLostPointerCaptureCapture
  - onPointerCancel
  - onPointerCancelCapture
  - onPointerDown
  - onPointerDownCapture
  - onPointerEnter
  - onPointerEnterCapture
  - onPointerLeave
  - onPointerLeaveCapture
  - onPointerMove
  - onPointerMoveCapture
  - onPointerOut
  - onPointerOutCapture
  - onPointerOver
  - onPointerOverCapture
  - onPointerUp
  - onPointerUpCapture

resolves #222