### PR TITLE
fix: add 'inputRef type parameter to various components

### DIFF
--- a/packages/rescript-mui-material/src/components/Autocomplete.res
+++ b/packages/rescript-mui-material/src/components/Autocomplete.res
@@ -147,17 +147,17 @@ type renderGroupParams = {
   children?: React.element,
 }
 
-type renderInputParams<'value> = {
+type renderInputParams<'value, 'inputRef> = {
   id: string,
   disabled: bool,
   fullWidth: bool,
   size: size,
   @as("InputLabelProps") inputLabelProps: InputLabel.props,
-  @as("InputProps") inputProps_: Input.props<'value>,
+  @as("InputProps") inputProps_: Input.props<'value, 'inputRef>,
   inputProps: InputBase.inputBaseComponentProps,
 }
 
-external renderInputParamsToTextFieldProps: renderInputParams<'a> => TextField.props<'value> =
+external renderInputParamsToTextFieldProps: renderInputParams<'a, 'inputRef> => TextField.props<'value, 'inputRef> =
   "%identity"
 
 type slotProps = {
@@ -167,7 +167,7 @@ type slotProps = {
   popupIndicator?: IconButton.props,
 }
 
-type autocompleteProps<'value> = {
+type autocompleteProps<'value, 'inputRef> = {
   ...CommonProps.t_NoId,
   /**
     * Array of options.
@@ -179,7 +179,7 @@ type autocompleteProps<'value> = {
     * @param {object} params
     * @returns {ReactNode}
     */
-  renderInput: renderInputParams<'value> => React.element,
+  renderInput: renderInputParams<'value, 'inputRef> => React.element,
   /**
     * If `true`, the portion of the selected suggestion that has not been typed by the user,
     * known as the completion string, appears inline after the input cursor in the textbox.
@@ -530,8 +530,8 @@ module Multiple = {
   @unboxed
   type multiple = | @as(true) True
 
-  type props<'value> = {
-    ...autocompleteProps<'value>,
+  type props<'value, 'inputRef> = {
+    ...autocompleteProps<'value, 'inputRef>,
     /**
       * The default value. Use when the component is not controlled.
       * @default []
@@ -570,11 +570,11 @@ module Multiple = {
   }
 
   @module("@mui/material/Autocomplete")
-  external make: React.component<props<'value>> = "default"
+  external make: React.component<props<'value, 'inputRef>> = "default"
 }
 
-type props<'value> = {
-  ...autocompleteProps<'value>,
+type props<'value, 'inputRef> = {
+  ...autocompleteProps<'value, 'inputRef>,
   /**
     * The default value. Use when the component is not controlled.
     * @default null
@@ -611,4 +611,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Autocomplete")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/Checkbox.res
+++ b/packages/rescript-mui-material/src/components/Checkbox.res
@@ -35,7 +35,7 @@ type edge =
   | @as("end") End
   | @as(false) False
 
-type props<'value> = {
+type props<'value, 'inputRef> = {
   ...ButtonBase.publicPropsWithOnClick,
   /**
     * If `true`, the component is checked.
@@ -103,7 +103,7 @@ type props<'value> = {
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<'value>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * Name attribute of the `input` element.
     */
@@ -139,4 +139,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Checkbox")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/FilledInput.res
+++ b/packages/rescript-mui-material/src/components/FilledInput.res
@@ -37,8 +37,8 @@ type classes = {
   inputTypeSearch?: string,
 }
 
-type props<'value> = {
-  ...InputBase.publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...InputBase.publicProps<'value, 'inputRef>,
   /**
     * Override or extend the styles applied to the component.
     */
@@ -64,4 +64,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/FilledInput")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/FormControlLabel.res
+++ b/packages/rescript-mui-material/src/components/FormControlLabel.res
@@ -34,7 +34,7 @@ type labelPlacement =
   | @as("top") Top
   | @as("bottom") Bottom
 
-type props<'value> = {
+type props<'value, 'inputRef> = {
   ...CommonProps.t,
   /**
     * A control element. For instance, it can be a `Radio`, a `Switch` or a `Checkbox`.
@@ -59,7 +59,7 @@ type props<'value> = {
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<unknown>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * A text or an element to be used in an enclosing label element.
     */
@@ -96,4 +96,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/FormControlLabel")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/Input.res
+++ b/packages/rescript-mui-material/src/components/Input.res
@@ -33,8 +33,8 @@ type classes = {
   inputTypeSearch?: string,
 }
 
-type props<'value> = {
-  ...InputBase.publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...InputBase.publicProps<'value, 'inputRef>,
   /**
     * Override or extend the styles applied to the component.
     */
@@ -53,4 +53,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Input")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/InputBase.res
+++ b/packages/rescript-mui-material/src/components/InputBase.res
@@ -90,7 +90,7 @@ type slots = {
   input?: React.element,
 }
 
-type publicProps<'value> = {
+type publicProps<'value, 'inputRef> = {
   ...CommonProps.t_NoId,
   /**
     * This prop helps users to fill forms faster, especially on mobile devices.
@@ -157,7 +157,7 @@ type publicProps<'value> = {
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<'value>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * If `dense`, will adjust vertical spacing. This is normally obtained via context from
     * FormControl.
@@ -256,8 +256,8 @@ type publicProps<'value> = {
   wrap?: CommonProps.wrap,
 }
 
-type props<'value> = {
-  ...publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...publicProps<'value, 'inputRef>,
   /**
     * Override or extend the styles applied to the component.
     */
@@ -276,4 +276,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/InputBase")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/NativeSelect.res
+++ b/packages/rescript-mui-material/src/components/NativeSelect.res
@@ -34,8 +34,8 @@ type variant =
   | @as("outlined") Outlined
   | @as("standard") Standard
 
-type props<'value> = {
-  ...InputBase.publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...InputBase.publicProps<'value, 'inputRef>,
   /**
     * The option elements to populate the select with.
     * Can be some `<option>` elements.
@@ -75,4 +75,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/NativeSelect")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/OutlinedInput.res
+++ b/packages/rescript-mui-material/src/components/OutlinedInput.res
@@ -33,16 +33,16 @@ type classes = {
   inputTypeSearch?: string,
 }
 
-type publicProps<'value> = {
-  ...InputBase.publicProps<'value>,
+type publicProps<'value, 'inputRef> = {
+  ...InputBase.publicProps<'value, 'inputRef>,
   /**
     * If `true`, the outline is notched to accommodate the label.
     */
   notched?: bool,
 }
 
-type props<'value> = {
-  ...publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...publicProps<'value, 'inputRef>,
   /**
     * Override or extend the styles applied to the component.
     */
@@ -65,4 +65,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/OutlinedInput")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/Radio.res
+++ b/packages/rescript-mui-material/src/components/Radio.res
@@ -33,7 +33,7 @@ type edge =
   | @as("end") End
   | @as(false) False
 
-type props<'value> = {
+type props<'value, 'inputRef> = {
   ...ButtonBase.publicPropsWithOnClick,
   /**
     * If `true`, the component is checked.
@@ -88,7 +88,7 @@ type props<'value> = {
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<'value>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * Name attribute of the `input` element.
     */
@@ -124,4 +124,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Radio")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/Select.res
+++ b/packages/rescript-mui-material/src/components/Select.res
@@ -32,8 +32,8 @@ type variant =
   | @as("outlined") Outlined
   | @as("filled") Filled
 
-type props<'value> = {
-  ...OutlinedInput.publicProps<'value>,
+type props<'value, 'inputRef> = {
+  ...OutlinedInput.publicProps<'value, 'inputRef>,
   /**
     * If `true`, the width of the popover will automatically be set according to the items inside the
     * menu, otherwise it will be at least the width of the select input.
@@ -162,4 +162,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Select")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/Switch.res
+++ b/packages/rescript-mui-material/src/components/Switch.res
@@ -49,7 +49,7 @@ type edge =
   | @as("end") End
   | @as(false) False
 
-type props<'value> = {
+type props<'value, 'inputRef> = {
   ...ButtonBase.publicPropsWithOnClick,
   /**
     * If `true`, the component is checked.
@@ -102,7 +102,7 @@ type props<'value> = {
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<'value>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * Name attribute of the `input` element.
     */
@@ -139,4 +139,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/Switch")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/TablePagination.res
+++ b/packages/rescript-mui-material/src/components/TablePagination.res
@@ -67,7 +67,7 @@ type labelDisplayedRowsArgs = {
   page: int,
 }
 
-type props = {
+type props<'inputRef> = {
   ...TableCell.publicProps,
   /**
     * The total number of rows.
@@ -163,7 +163,7 @@ type props = {
     * @default {}
     */
   @as("SelectProps")
-  selectProps?: Select.props<int>,
+  selectProps?: Select.props<int, 'inputRef>,
   /**
     * If `true`, show the first-page button.
     * @default false
@@ -181,4 +181,4 @@ type props = {
 }
 
 @module("@mui/material/TablePagination")
-external make: React.component<props> = "default"
+external make: React.component<props<'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/components/TextField.res
+++ b/packages/rescript-mui-material/src/components/TextField.res
@@ -24,7 +24,7 @@ type variant =
   | @as("outlined") Outlined
   | @as("filled") Filled
 
-type props<'value> = {
+type props<'value, 'inputRef> = {
   ...CommonProps.t,
   ...CommonProps.inputTextareaProps,
   ...CommonProps.eventHandlerProps,
@@ -86,11 +86,11 @@ type props<'value> = {
     * component depending on the `variant` prop value.
     */
   @as("InputProps")
-  inputProps_?: Input.props<'value>,
+  inputProps_?: Input.props<'value, 'inputRef>,
   /**
     * Pass a ref to the `input` element.
     */
-  inputRef?: React.ref<unknown>,
+  inputRef?: React.ref<'inputRef>,
   /**
     * The label content.
     */
@@ -123,7 +123,7 @@ type props<'value> = {
     * Props applied to the [`Select`](/material-ui/api/select/) element.
     */
   @as("SelectProps")
-  selectProps?: Select.props<'value>,
+  selectProps?: Select.props<'value, 'inputRef>,
   /**
     * The size of the component.
     */
@@ -143,4 +143,4 @@ type props<'value> = {
 }
 
 @module("@mui/material/TextField")
-external make: React.component<props<'value>> = "default"
+external make: React.component<props<'value, 'inputRef>> = "default"

--- a/packages/rescript-mui-material/src/types/Overrides.res
+++ b/packages/rescript-mui-material/src/types/Overrides.res
@@ -1321,7 +1321,7 @@ type t = {
   @as("MuiAlertTitle") muiAlertTitle?: component<alertTitleClassKey, AlertTitle.props>,
   @as("MuiAppBar") muiAppBar?: component<appBarClassKey, AppBar.props>,
   @as("MuiAutocomplete")
-  muiAutocomplete?: component<autocompleteClassKey, Autocomplete.props<unknown>>,
+  muiAutocomplete?: component<autocompleteClassKey, Autocomplete.props<unknown, unknown>>,
   @as("MuiAvatar") muiAvatar?: component<avatarClassKey, Avatar.props>,
   @as("MuiAvatarGroup") muiAvatarGroup?: component<avatarGroupClassKey, AvatarGroup.props>,
   @as("MuiBackdrop") muiBackdrop?: component<backdropClassKey, Backdrop.props>,
@@ -1344,7 +1344,7 @@ type t = {
   @as("MuiCardContent") muiCardContent?: component<cardContentClassKey, CardContent.props>,
   @as("MuiCardHeader") muiCardHeader?: component<cardHeaderClassKey, CardHeader.props>,
   @as("MuiCardMedia") muiCardMedia?: component<cardMediaClassKey, CardMedia.props>,
-  @as("MuiCheckbox") muiCheckbox?: component<checkboxClassKey, Checkbox.props<unknown>>,
+  @as("MuiCheckbox") muiCheckbox?: component<checkboxClassKey, Checkbox.props<unknown, unknown>>,
   @as("MuiChip") muiChip?: component<chipClassKey, Chip.props>,
   @as("MuiCircularProgress")
   muiCircularProgress?: component<circularProgressClassKey, CircularProgress.props>,
@@ -1359,10 +1359,10 @@ type t = {
   @as("MuiDivider") muiDivider?: component<dividerClassKey, Divider.props>,
   @as("MuiDrawer") muiDrawer?: component<drawerClassKey, Drawer.props>,
   @as("MuiFab") muiFab?: component<fabClassKey, Fab.props>,
-  @as("MuiFilledInput") muiFilledInput?: component<filledInputClassKey, FilledInput.props<unknown>>,
+  @as("MuiFilledInput") muiFilledInput?: component<filledInputClassKey, FilledInput.props<unknown, unknown>>,
   @as("MuiFormControl") muiFormControl?: component<formControlClassKey, FormControl.props>,
   @as("MuiFormControlLabel")
-  muiFormControlLabel?: component<formControlLabelClassKey, FormControlLabel.props<unknown>>,
+  muiFormControlLabel?: component<formControlLabelClassKey, FormControlLabel.props<unknown, unknown>>,
   @as("MuiFormGroup") muiFormGroup?: component<formGroupClassKey, FormGroup.props>,
   @as("MuiFormHelperText")
   muiFormHelperText?: component<formHelperTextClassKey, FormHelperText.props>,
@@ -1374,10 +1374,10 @@ type t = {
   @as("MuiImageListItem") muiImageListItem?: component<imageListItemClassKey, ImageListItem.props>,
   @as("MuiImageListItemBar")
   muiImageListItemBar?: component<imageListItemBarClassKey, ImageListItemBar.props>,
-  @as("MuiInput") muiInput?: component<inputClassKey, Input.props<unknown>>,
+  @as("MuiInput") muiInput?: component<inputClassKey, Input.props<unknown, unknown>>,
   @as("MuiInputAdornment")
   muiInputAdornment?: component<inputAdornmentClassKey, InputAdornment.props>,
-  @as("MuiInputBase") muiInputBase?: component<inputBaseClassKey, InputBase.props<unknown>>,
+  @as("MuiInputBase") muiInputBase?: component<inputBaseClassKey, InputBase.props<unknown, unknown>>,
   @as("MuiInputLabel") muiInputLabel?: component<inputLabelClassKey, InputLabel.props>,
   @as("MuiLinearProgress")
   muiLinearProgress?: component<linearProgressClassKey, LinearProgress.props>,
@@ -1401,20 +1401,20 @@ type t = {
   @as("MuiMobileStepper") muiMobileStepper?: component<mobileStepperClassKey, MobileStepper.props>,
   @as("MuiModal") muiModal?: component<modalClassKey, Modal.props>,
   @as("MuiNativeSelect")
-  muiNativeSelect?: component<nativeSelectClassKey, NativeSelect.props<unknown>>,
+  muiNativeSelect?: component<nativeSelectClassKey, NativeSelect.props<unknown, unknown>>,
   @as("MuiOutlinedInput")
-  muiOutlinedInput?: component<outlinedInputClassKey, OutlinedInput.props<unknown>>,
+  muiOutlinedInput?: component<outlinedInputClassKey, OutlinedInput.props<unknown, unknown>>,
   @as("MuiPagination") muiPagination?: component<paginationClassKey, Pagination.props>,
   @as("MuiPaginationItem")
   muiPaginationItem?: component<paginationItemClassKey, PaginationItem.props>,
   @as("MuiPaper") muiPaper?: component<paperClassKey, Paper.props>,
   @as("MuiPopover") muiPopover?: component<popoverClassKey, Popover.props>,
   @as("MuiPopper") muiPopper?: component<popperClassKey, Popper.props>,
-  @as("MuiRadio") muiRadio?: component<radioClassKey, Radio.props<unknown>>,
+  @as("MuiRadio") muiRadio?: component<radioClassKey, Radio.props<unknown, unknown>>,
   @as("MuiRating") muiRating?: component<ratingClassKey, Rating.props>,
   @as("MuiScopedCssBaseline")
   muiScopedCssBaseline?: component<scopedCssBaselineClassKey, ScopedCssBaseline.props>,
-  @as("MuiSelect") muiSelect?: component<selectClassKey, Select.props<unknown>>,
+  @as("MuiSelect") muiSelect?: component<selectClassKey, Select.props<unknown, unknown>>,
   @as("MuiSkeleton") muiSkeleton?: component<skeletonClassKey, Skeleton.props>,
   @as("MuiSlider") muiSlider?: component<sliderClassKey, Slider.props>,
   @as("MuiSnackbar") muiSnackbar?: component<snackbarClassKey, Snackbar.props>,
@@ -1433,7 +1433,7 @@ type t = {
   @as("MuiStepLabel") muiStepLabel?: component<stepLabelClassKey, StepLabel.props>,
   @as("MuiStepper") muiStepper?: component<stepperClassKey, Stepper.props>,
   @as("MuiSvgIcon") muiSvgIcon?: component<svgIconClassKey, SvgIcon.props>,
-  @as("MuiSwitch") muiSwitch?: component<switchClassKey, Switch.props<unknown>>,
+  @as("MuiSwitch") muiSwitch?: component<switchClassKey, Switch.props<unknown, unknown>>,
   @as("MuiTab") muiTab?: component<tabClassKey, Tab.props<unknown>>,
   @as("MuiTabScrollButton")
   muiTabScrollButton?: component<tabScrollButtonClassKey, TabScrollButton.props>,
@@ -1445,12 +1445,12 @@ type t = {
   @as("MuiTableFooter") muiTableFooter?: component<tableFooterClassKey, TableFooter.props>,
   @as("MuiTableHead") muiTableHead?: component<tableHeadClassKey, TableHead.props>,
   @as("MuiTablePagination")
-  muiTablePagination?: component<tablePaginationClassKey, TablePagination.props>,
+  muiTablePagination?: component<tablePaginationClassKey, TablePagination.props<unknown>>,
   @as("MuiTableRow") muiTableRow?: component<tableRowClassKey, TableRow.props>,
   @as("MuiTableSortLabel")
   muiTableSortLabel?: component<tableSortLabelClassKey, TableSortLabel.props>,
   @as("MuiTabs") muiTabs?: component<tabsClassKey, Tabs.props<unknown>>,
-  @as("MuiTextField") muiTextField?: component<textFieldClassKey, TextField.props<unknown>>,
+  @as("MuiTextField") muiTextField?: component<textFieldClassKey, TextField.props<unknown, unknown>>,
   @as("MuiToggleButton")
   muiToggleButton?: component<toggleButtonClassKey, ToggleButton.props<unknown>>,
   @as("MuiToggleButtonGroup")

--- a/packages/rescript-mui-x-date-pickers/src/DateField.res
+++ b/packages/rescript-mui-x-date-pickers/src/DateField.res
@@ -26,7 +26,7 @@ type variant =
 
 type fieldChangeHandlerContext<'error>
 
-type props<'value, 'error> = {
+type props<'value, 'error, 'inputRef> = {
   /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
@@ -116,11 +116,11 @@ type props<'value, 'error> = {
    * component depending on the `variant` prop value.
    */
   @as("InputProps")
-  inputProps_?: Mui.Input.props<'value>,
+  inputProps_?: Mui.Input.props<'value, 'inputRef>,
   /**
    * Pass a ref to the `input` element.
    */
-  inputRef?: React.ref<'value>,
+  inputRef?: React.ref<'inputRef>,
   /**
    * The label content.
    */
@@ -271,4 +271,4 @@ type props<'value, 'error> = {
 }
 
 @module("@mui/x-date-pickers")
-external make: React.component<props<'value, 'error>> = "DateField"
+external make: React.component<props<'value, 'error, 'inputRef>> = "DateField"


### PR DESCRIPTION
This is a potentially disruptive change, but really you couldn't use this without opting out of type safety.

- Autocomplete
- Checkbox
- FilledInput
- FormControlLabel
- Input
- InputBase
- NativeSelect
- OutlinedInput
- Radio
- Select
- Switch
- TablePagination
- TextField
- [Theme] Overrides
- DateField

resolves TextField inputRef being typed as unknown means you can't pass it a ref #220